### PR TITLE
Profile: Show Gravatar when no profile uploaded yet - improve

### DIFF
--- a/app/Components/SpeakerList/SpeakerList.latte
+++ b/app/Components/SpeakerList/SpeakerList.latte
@@ -10,7 +10,7 @@
                     {var $conferee = $talk->conferee}
                     <li>
                         <a href="{plink :Conference:talkDetail, 'id' => $talk->id}" class="item">
-                            <div class="item-image" style="background-image: url({$conferee->pictureUrl})"></div>
+                            <div class="item-image" style="background-image: url({gravatarize($conferee->pictureUrl, $conferee->email)})"></div>
                             <div class="item-content">
                                 <h2 class="item-title">{$conferee->name}</h2>
                                 <span class="item-meta" title="{$conferee->bio|stripHtml}">{$conferee->bio|stripHtml|truncate:40}</span>

--- a/app/Components/SpeakerList/SpeakerListControl.php
+++ b/app/Components/SpeakerList/SpeakerListControl.php
@@ -3,6 +3,7 @@
 namespace App\Components\SpeakerList;
 
 use App\Model\EventInfoProvider;
+use App\Model\GravatarImageProvider;
 use App\Model\TalkManager;
 use App\Orm\Talk\Talk;
 use Nette\Application\UI\Control;
@@ -17,7 +18,8 @@ class SpeakerListControl extends Control
      */
     public function __construct(
         private readonly TalkManager $talkManager,
-        private readonly EventInfoProvider $eventInfoProvider
+        private readonly EventInfoProvider $eventInfoProvider,
+        private readonly GravatarImageProvider $gravatarImageProvider,
     ) {
     }
 
@@ -39,6 +41,7 @@ class SpeakerListControl extends Control
         $this->template->setFile(__DIR__ . '/SpeakerList.latte');
         $this->template->talks = $talks;
         $this->template->isProgram = $this->eventInfoProvider->getFeatures()['program'];
+        $this->template->addFunction('gravatarize', $this->gravatarImageProvider->gravatarize(...));
         $this->template->render();
     }
 }

--- a/app/Model/GravatarImageProvider.php
+++ b/app/Model/GravatarImageProvider.php
@@ -6,11 +6,24 @@ namespace App\Model;
 
 class GravatarImageProvider
 {
+    private string $fallbackUrl;
+
     public function __construct(
         private readonly int $size,
-        private readonly string $fallbackUrl,
+        string $fallbackUrl,
+        EventInfoProvider $infoProvider
     )
     {
+        $year = $infoProvider->getDates()->year;
+        $this->fallbackUrl = strtr($fallbackUrl, ['{year}' => $year]);
+    }
+
+    /**
+     * Returns the Gravatar URL if `$url` is null, otherwise returns `$url`.
+     */
+    public function gravatarize(?string $url, string $email): string
+    {
+        return $url ?? $this->getGravatarUrl($email);
     }
 
     public function getGravatarUrl(string $email): string

--- a/app/Presenters/BasePresenter.php
+++ b/app/Presenters/BasePresenter.php
@@ -4,6 +4,7 @@ namespace App\Presenters;
 
 use App\Model\ArchiveManager;
 use App\Model\EventInfoProvider;
+use App\Model\GravatarImageProvider;
 use Nette;
 use Nextras\Application\UI\SecuredLinksPresenterTrait;
 
@@ -14,26 +15,23 @@ abstract class BasePresenter extends Nette\Application\UI\Presenter
 {
     use SecuredLinksPresenterTrait;
 
-    /**
-     * @var EventInfoProvider $eventInfo
-     */
-    protected $eventInfo;
-    /**
-     * @var bool $isArchivationProcess True when archivation process is currently running & in progress
-     */
+    protected EventInfoProvider $eventInfo;
+    /** True when archivation process is currently running & in progress*/
     private ?bool $isArchivationProcess = null;
     private Nette\DI\Container $container;
+    private GravatarImageProvider $gravatarImageProvider;
 
 
-    /**
-     * @param EventInfoProvider $eventInfo
-     * @param ArchiveManager $archiveManager
-     */
-    public function inject(EventInfoProvider $eventInfo, ArchiveManager $archiveManager, Nette\DI\Container $container): void
-    {
+    public function inject(
+        EventInfoProvider $eventInfo,
+        ArchiveManager $archiveManager,
+        Nette\DI\Container $container,
+        GravatarImageProvider $gravatarImageProvider
+    ): void {
         $this->eventInfo = $eventInfo;
         $this->isArchivationProcess = $archiveManager->isArchivationProcess();
         $this->container = $container;
+        $this->gravatarImageProvider = $gravatarImageProvider;
     }
 
 
@@ -66,8 +64,12 @@ abstract class BasePresenter extends Nette\Application\UI\Presenter
         $this->template->isArchivationProcess = $this->isArchivationProcess;
 
         $this->template->addFunction('isPassed', $this->isDatePassed(...));
+        $this->template->addFunction('gravatarize', $this->gravatarImageProvider->gravatarize(...));
     }
 
+    /**
+     * @deprecated Stav webu by měl být řízen spíš stavem, než porovnánávním s aktuálním datem
+     */
     private function isDatePassed(\DateTimeInterface $date): bool
     {
         return $date < new \DateTimeImmutable();

--- a/app/Presenters/ConferencePresenter.php
+++ b/app/Presenters/ConferencePresenter.php
@@ -85,6 +85,7 @@ class ConferencePresenter extends BasePresenter
 
         $this->template->votes = $votes;
         $this->template->allowVote = $this->eventInfoProvider->getFeatures()['vote'];
+        $this->template->allowTalkEdit = $this->eventInfoProvider->getFeatures()['talks_edit'];
         $this->template->selectedLimit = false;
 
         $talks_limit = $this->eventInfoProvider->getCounts()['talks_limit'];

--- a/app/Presenters/templates/Conference/talkDetail.latte
+++ b/app/Presenters/templates/Conference/talkDetail.latte
@@ -1,5 +1,5 @@
 {block title}Přednáška {$talk->title}{/block}
-{block ogImage}{ifset $ogImageUrl}{$ogImageUrl}{else}{$talk->conferee->pictureUrl}{/ifset}{/block}
+{block ogImage}{ifset $ogImageUrl}{$ogImageUrl}{else}{gravatarize($talk->conferee->pictureUrl, $talk->conferee->email)}{/ifset}{/block}
 {block content}
 
 <section>
@@ -61,7 +61,7 @@
                     </div>
                 </div>
                 <div class="pure-u-1 pure-u-md-1-3 item-author">
-                    <img class="item-image failover" src="{$talk->conferee->pictureUrl}">
+                    <img class="item-image failover" src="{gravatarize($talk->conferee->pictureUrl, $talk->conferee->email)}">
                     <div class="item-author-name">{$talk->conferee->name}</div>
                     <div n:ifcontent class="item-meta">{$talk->company}</div>
 
@@ -70,6 +70,10 @@
                             <span class="item-count">{$talk->votes}</span> hlasů
                         {/if}
                         <div n:ifcontent class="item-buttons">
+                            {if allowTalkEdit && $user->isLoggedIn() && $talk->conferee->user->id == $user->id}
+                            <a href="{link User:talk}" class="btn btn-sm btn-secondary">Upravit přednášku</a>
+                            <a href="{link User:conferee}" class="btn btn-sm btn-secondary">Upravit profil</a>
+                            {/if}
                             {if $allowVote}
                                 {if !$user->isLoggedIn()}
                                     <a href="{link signToVote!}" class="btn btn-sm btn-secondary">Přihlas se a hlasuj</a>

--- a/app/Presenters/templates/Conference/talks.latte
+++ b/app/Presenters/templates/Conference/talks.latte
@@ -44,7 +44,7 @@
             <li n:class="$isOver ? old, $isFirstOver ? first">
                 <div class="item-header">
                     <span class="item-number">{$iterator->counter}</span>
-                    <img src="{$conferee->pictureUrl}" alt="author" class="item-image failover" width="65" height="65">
+                    <img src="{gravatarize($conferee->pictureUrl, $conferee->email)}" alt="author" class="item-image failover" width="65" height="65">
                     <div class="item-author">
                         <span class="item-author-name">{$conferee->name}</span>
                         <span n:ifcontent class="item-meta" title="{$talk->company}">{$talk->company|truncate:35}</span>

--- a/app/Presenters/templates/User/profil.latte
+++ b/app/Presenters/templates/User/profil.latte
@@ -8,7 +8,7 @@
             <ul class="row people-list flexible mt-xs">
                 <li>
                     <div class="item">
-                        <div id="avatar" class="item-image" style="background-image: url('{$profileImage}')"></div>
+                        <div id="avatar" class="item-image" style="background-image: url('{gravatarize($user->identity->pictureUrl, $user->identity->email)}')"></div>
                         <div class="item-content">
                             <h2 class="item-title">{$user->identity->name}</h2>
                             <span n:if="$conferee" class="item-meta" title="{$conferee->bio|stripHtml}">{$conferee->bio|stripHtml|truncate:50|breakLines}</span>
@@ -22,6 +22,9 @@
                                 {/if}
 
                                 {if count($talks)}
+                                    {foreach $talks as $talk}
+                                        <a href="{link Conference:talkDetail $talk->id}" class="btn btn-brand btn-tiny btn-block mt-xs">Zobrazit tvoji přednášku</a>
+                                    {/foreach}
                                     <a n:if="$allowEditTalk" href="{link talk}" class="btn btn-brand btn-tiny btn-block mt-xs">Upravit přednášku</a>
                                 {else}
                                     <a n:if="$allowRegisterTalk" href="{link Sign:talk}" class="btn btn-secondary btn-tiny btn-block mt-xs">Vypsat přednášku</a>


### PR DESCRIPTION
PR doplňuje gravatar i tam, kde nebyl:

- profil uživatele,
- seznam přednášek,
- detail přednášky,
- seznam speakerů na HP.

Dále je na profilu uživatele, který má vypsanou přednášku, zobrazeno tlačítko pro zobrazení jeho přednášky (neměl se tam dosud jak dostat přímo, musel svoji přednášku hledat mezi ostatníma).

<img width="334" alt="250414-xh2ff" src="https://github.com/user-attachments/assets/bf03ecab-0672-4b77-99b3-13aa6b3c26be" />

Dále v detailu své přednášky má přihlášený uživatel nově tlačítka pro editaci přednášky a profilu, aby mohl vzhled přednášky doladit hned bez nutnosti hledat, kde se to dělá. Toto je zobrazeno pouze po dobu, co je v harmonogramu povolená editace přednášek.

<img width="400" alt="250414-vl0vj" src="https://github.com/user-attachments/assets/f82746fd-acc9-4b19-9d6d-4339296e8118" />


Tento tak nebyl v úkolech, opravil jsem v něm to, co mě rvalo žíly jako přednášejícímu.

