### PR TITLE
Database reconfiguration

### DIFF
--- a/.deployment.php
+++ b/.deployment.php
@@ -30,6 +30,7 @@ return [
             /.install
             /.rsync-exclude
             /app/config/config.local.neon
+            /app/config/config.local-sample.neon
             /assets
             /bin
             /bower.json

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Požadavky pro běh
 
 PHP 8.3 nebo vyšší, Mysql, Git, Unzip. 
 
-V PHP jsou potřeba rozšření: `mysqli`, `pdo_mysql`.
+V PHP jsou potřeba rozšření: `pdo_mysql`.
 
 
 Požadavky pro vývoj

--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@ Instalace na localhost
 
 Po stažení repozitáře naisntalujte závislosti:
 
-    composer install
+```shell
+composer install
+```
 
 Vytvořte soubor `app/config/config.local.neon` (není verzován v Gitu). Může být i prázdný.
 
@@ -18,13 +20,17 @@ Vytvořte soubor `app/config/config.local.neon` (není verzován v Gitu). Může
 
 Pro úpravy JavaScriptových souborů a nebo stylů je potřeba nainstalovat závislosti pro generátor:
 
-    npm install -g bower
-    npm install
-    bower install
-    
+```shell
+npm install -g bower grunt-cli
+npm install
+bower install
+```
+
 Po úpravě souborů v `assets/` zavolejte:
 
-    grunt
+```shell
+grunt
+```
 
 a vygenerují se soubory:
 - `www/js/main.js`
@@ -34,20 +40,22 @@ a vygenerují se soubory:
 
 které obsahují veškeré scripty a styly stránek. Tyto soubory jsou součástí repozitáře, takže je lze
 rovnou použít. 
- 
+
 
 Spuštění webového serveru
 -------------------------
 Spusťte Docker 
 
-    docker-composer up -d
+```shell
+docker compose up -d
+```
 
 Na stránce `http://localhost:8080` by se měl objevit aktuální web.
 
 Nastavení cronu
 --------------
 
-Vy systému není univerzální cron, který by obsluhoval všechny služby, ale pro každý cronem obsluhovaný
+V systému není univerzální cron, který by obsluhoval všechny služby, ale pro každý cronem obsluhovaný
 job je samostatné volání cronu. 
 
 Volání cronu je přes HTTPS REST API a je chráněno API tokenem, který si lze vygenerovat v administraci.
@@ -77,11 +85,40 @@ V PHP jsou potřeba rozšření: `pdo_mysql`.
 Požadavky pro vývoj
 -----------------
 
-Composer, NPM 
+Composer, NPM
 
+Požadavky na webhosting
+-----------------------
 
-Deploy na server
-----------------
+- všechny pozadavky uvedené v kapitole [Požadavky pro běh](#pozadavky-pro-beh).
+- webserver musí mít povolený `mod_rewrite`.
+- webserver musí mít `DOCUMENT_ROOT` směrovaný do adresáře `www/`, nikoliv do rootu repozitáře.
+
+> [!WARNING]
+> Pokud váš webhosting nemá možnost nastavit `DOCUMENT_ROOT` do adresáře `www/`, zvolte si jiný webhosting
+> a nepokoušejte se tento neodstatek vyřešit přes `.htaccess` soubor. Jedná se o zásadní bezpečnostní aspekt.\
+> Více informací: https://nette.org/cs/security-warning
+
+- v rootu aplikace musí být vytvořeny adresáře `temp/` a `log/` a musí mít nastaveny práva pro zápis (tyto adresáře
+    nejsou součástí deploye, je proto potřeba je vytvořit ručně).
+- na serveru musí existovat soubor [`app/config/config.local.neon`] (klidně prázdný pro začátek).
+
+Aplikace potřebuje pro běh připojení k MySQL (nebo MariaDB) databázi a v ní připravené tabulky, jejich struktura je
+v souboru [`.install/structure.sql`](.install/structure.sql). Konfigurační tabulka musí obsahovat základní data, která
+jsou vypsána v souboru [`.install/base-data.sql`](.install/base-data.sql).
+
+Budete potřebovat do aplikace zadat přístupové údaje k databázi. Nezadávejte je do hlavního konfiguračního souboru,
+protože byste si tím rozbili lokální vývoj. K tomu slouží soubor `config.local.neon`, který není verzován a ani
+není součástí deploye, takže se vaše lokální verze nebude propisovat na server – což ale znamená, že jej na server
+musíte nahrát ručně. Doporučená struktura tohoto souboru je připravena v souboru
+[`config.local-sample.neon`](app/config/config.local-sample.neon).
+
+Deploy na server přes FTP
+-------------------------
+
+Tento návod přepokládá, že k serveru přistupujete přes FTP. Pokud používáte jinou metodu (SCP, SFTP, rsync apod.),
+můžete tento návod přeskočit a jako podklad pro vlastní deploy script použijte soubor [`.deployment.php`](.deployment.php),
+zejména seznam ignorovaných cest, které se nemají nasazovat na server.
 
 Pro automatický deploy změn na produkční server je potřeba mít nainstalovaný composer a v něm **globálně** nainstalovaný
 balíček [`ftp-deployment`](https://github.com/dg/ftp-deployment):
@@ -97,9 +134,9 @@ composer global require dg/ftp-deployment
 <?php
 
 return [
-     'remote' => <fill in your FTP url - e.g. ftps://example.com/path/to/your/dir>,
-     'user' => <fill in your FTP username>,
-     'password' => <fill in your FTP password>
+ 'remote' => <fill in your FTP url - e.g. ftps://example.com/path/to/your/dir>,
+ 'user' => <fill in your FTP username>,
+ 'password' => <fill in your FTP password>
 ];
 ```
 
@@ -113,6 +150,5 @@ Deploy lze spustit připravenými scripty:
 
 License
 -------
-- Web: The MIT License (MIT)
-- Nette: New BSD License or GPL 2.0 or 3.0
+- The MIT License (MIT)
 - Další závislosti podle zveřejněných licení

--- a/app/Dbal/RawPdoMysqlDriver.php
+++ b/app/Dbal/RawPdoMysqlDriver.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Dbal;
+
+use Nextras\Dbal\Drivers\PdoMysql\PdoMysqlDriver;
+use Nextras\Dbal\Drivers\PdoMysql\PdoMysqlResultNormalizerFactory;
+use Nextras\Dbal\ILogger;
+use PDO;
+
+class RawPdoMysqlDriver extends PdoMysqlDriver
+{
+    public function connect(array $params, ILogger $logger): void
+    {
+        $pdo = $params['pdo'] ?? null;
+
+        if (!$pdo instanceof PDO) {
+            $type = get_debug_type($pdo);
+            throw new \InvalidArgumentException(__CLASS__ . " expects PDO instance at `pdo` parameter, got '{$type}'.");
+        }
+
+        if ($pdo->getAttribute(PDO::ATTR_DRIVER_NAME) !== 'mysql') {
+            $driverName = $pdo->getAttribute(PDO::ATTR_DRIVER_NAME);
+            throw new \InvalidArgumentException(
+                __CLASS__ . " expects PDO instance with MySQL driver, got '{$driverName}'."
+            );
+        }
+
+        $this->connection = $pdo;
+        $this->logger = $logger;
+
+        // Workaround to fill private $this->resultNormalizerFactory
+        (function ($factory) {
+            $this->resultNormalizerFactory = $factory;
+        })->bindTo($this, PdoMysqlDriver::class)(
+            new PdoMysqlResultNormalizerFactory($this)
+        );
+    }
+
+}

--- a/app/config/config.local-sample.neon
+++ b/app/config/config.local-sample.neon
@@ -1,0 +1,14 @@
+# This is a sample configuration file.
+# Copy this file to config.local.neon and fill in the required values.
+# The file config.local.neon is not tracked by git, so you can safely put your passwords here.
+
+parameters:
+#     mail:
+#         password: put-password-here
+
+#     api_token_secretkey: put-token-here
+
+#database:
+#    dsn: "mysql:host=____________;dbname=____________;charset=utf8mb4"
+#    user: put-username-here
+#    password: put-password-here

--- a/app/config/config.neon
+++ b/app/config/config.neon
@@ -3,13 +3,6 @@
 # https://nette.org/security-warning
 #
 parameters:
-    database:
-        driver: mysqli
-        host: barcampkolinweb_mysqldb_1
-        dbname: barcampkolin
-        user: root
-        password: redbitmasters
-        port: 3306
     mail:
         from: "Barcamp Kolín <info@barcampkolin.cz>"
     api_token_secretkey: {secret-token}
@@ -40,13 +33,8 @@ extensions:
     nextras.orm: Nextras\Orm\Bridges\NetteDI\OrmExtension
 
 nextras.dbal:
-    driver: %database.driver%
-    host: %database.host%
-    database: %database.dbname%
-    username: %database.user%
-    password: %database.password%
-    connectionTz: '+2:00'
-    port: %database.port%
+    driver: App\Dbal\RawPdoMysqlDriver()
+    pdo: @database.default.connection::getPdo()
 
 nextras.orm:
     model: App\Orm\Orm
@@ -77,9 +65,9 @@ http:
         ]
 
 database:
-    dsn: 'mysql:host=%database.host%;dbname=%database.dbname%'
-    user: %database.user%
-    password: %database.password%
+    dsn: "mysql:host=mysqldb;dbname=default;charset=utf8mb4"
+    user: root
+    password: devstack
     options:
         lazy: yes
 


### PR DESCRIPTION
Tento PR refaktoruje konfiguraci databáze. Z historických důvodů se aplikace při každém requestu připojila k databázi 2 paralelními spojeními, protože neuměla sdílet jedno spojení mezi vrstvami Nette/Database a Nextras/Dbal. Prakticky to nemělo žádný praktický důvod.

Tento PR řeší tento problém a jedno spojení nyní sdílí mezi oběma vrstvami. tato aplikace nepoužívá transakce ani jiné stavové funkce DB, sdílení připojení by tedy nemělo mít side-efect.

> [!IMPORTANT]
> Tento PR podstatně mění konfiguraci databáze a je potřeba provést úpravy v souboru `config.local.neon`!

Pokud máte v souboru `config.local.neon` vlastní údaje k připojení do DB, tak se změnil jejich způsob zápisu. Databáze již nevyužívá definici údajů v sekci `parameters`, a vyžaduje údaje ve tvaru DSN. **Ukázku toho, jak má být soubor upraven, jsem připravil v souboru [`config.local-sample.neon`](https://github.com/barcampkolin/barcampkolin-web/blob/master/app/config/config.local-sample.neon)**.

> [!NOTE]  
> V souboru `RawPdoMysqlDriver.php` je ošklivý hack pro přepsání privátní proměnné cizí třídy. Řeší to chybu v externí knihovně, je to workaround na PR nextras/dbal#291.
