### PR TITLE
Update to PHP 8.4

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -11,7 +11,6 @@ jobs:
             fail-fast: false
             matrix:
                 php:
-                    - "8.3"
                     - "8.4"
         steps:
             -   name: Checkout repo
@@ -84,7 +83,6 @@ jobs:
             fail-fast: false
             matrix:
                 php:
-                    - "8.3"
                     - "8.4"
         steps:
             -   name: Checkout repo

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
 	],
 	"homepage": "https://www.barcampkolin.cz/",
 	"require": {
-		"php": "^8.3",
+		"php": "~8.4.0",
 		"kdyby/forms-replicator": "3.0.0-rc1",
 		"latte/latte": "^3.0",
 		"nette/application": "^3.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9146a8fc5ae7a41fc4f2492b93cdbd4c",
+    "content-hash": "edc202c5d859e03147bc8ee5ebe60984",
     "packages": [
         {
             "name": "contributte/application",
@@ -2947,8 +2947,8 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^8.3"
+        "php": "~8.4.0"
     },
     "platform-dev": {},
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
     web:
-        image: jakubboucek/lamp-devstack-php:8.3-debug
+        image: jakubboucek/lamp-devstack-php:8.4-debug
         environment:
             # APACHE_DOCUMENT_ROOT: "/var/www/html"
             APP_DEBUG: 1


### PR DESCRIPTION
Aktualizace verze běhového prostředí na PHP 8.4.

V předchozích úpravách byly odstraněny blockery pro update na PHP 8.4 a již delší dobu jsou doplněny CI testy pro tuto verzi, které procházení, proto nyní je na místě upgrade. 

## Release note

 - [x] Update production server configuration

## Note

PHP 8.5 zatím není možné:

```
$ composer why-not php 8.5
latte/latte            v3.0.20    requires php (8.0 - 8.4)
nette/application      v3.2.6     requires php (8.1 - 8.4)
nette/bootstrap        v3.2.5     requires php (8.0 - 8.4)
nette/caching          v3.3.1     requires php (8.0 - 8.4)
nette/component-model  v3.1.1     requires php (8.1 - 8.4)
nette/database         v3.2.6     requires php (8.1 - 8.4)
nette/di               v3.2.4     requires php (8.1 - 8.4)
nette/forms            v3.2.6     requires php (8.1 - 8.4)
nette/http             v3.3.2     requires php (8.1 - 8.4)
nette/mail             v4.0.3     requires php (8.0 - 8.4)
nette/neon             v3.4.4     requires php (8.0 - 8.4)
nette/php-generator    v4.1.8     requires php (8.0 - 8.4)
nette/robot-loader     v4.0.3     requires php (8.0 - 8.4)
nette/routing          v3.1.1     requires php (8.1 - 8.4)
nette/safe-stream      v3.0.2     requires php (8.0 - 8.4)
nette/schema           v1.3.2     requires php (8.1 - 8.4)
nette/security         v3.2.1     requires php (8.1 - 8.4)
nette/utils            v4.0.6     requires php (8.0 - 8.4)
tracy/tracy            v2.10.9    requires php (8.0 - 8.4)
```

