### PR TITLE
.htaccess: add support for WebP & AVIF file types

### DIFF
--- a/www/.htaccess
+++ b/www/.htaccess
@@ -37,6 +37,8 @@ AddType image/svg+xml .svg
 AddType application/x-font-ttf .ttf
 AddType application/font-woff .woff
 AddType font/woff2 .woff2
+AddType image/webp .webp
+AddType image/avif .avif
 
 ExpiresActive On
 ExpiresByType text/html "access plus 1 hour"
@@ -44,6 +46,8 @@ ExpiresByType application/javascript "access plus 1 month"
 ExpiresByType text/css "access plus 1 month"
 ExpiresByType image/jpeg "access plus 1 month"
 ExpiresByType image/png "access plus 1 month"
+ExpiresByType image/webp "access plus 1 month"
+ExpiresByType image/avif "access plus 1 month"
 ExpiresByType image/vnd.microsoft.icon "access plus 1 month"
 ExpiresByType application/vnd.ms-fontobject "access plus 1 month"
 ExpiresByType application/x-font-opentype "access plus 1 month"


### PR DESCRIPTION
Server aktuálně nativně nepodporuje WebP a AVIF soubory (neposílá správné [MIME hlavičky](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/MIME_types). 

PR jen upravuje `.htaccess` soubor, kam doplňuje typy. Není tam žádná nová funkcionalita, pouze se v již existujícím sezamu rozšiřuje výčet deklarovaných typů.