### PR TITLE
Improve code – strict types of `EventInfo` datasets

### DIFF
--- a/app/AdminModule/Presenters/BasePresenter.php
+++ b/app/AdminModule/Presenters/BasePresenter.php
@@ -51,6 +51,6 @@ class BasePresenter extends Presenter
     {
         parent::beforeRender();
         $dates = $this->eventInfo->getDates();
-        $this->template->year = $dates['year'];
+        $this->template->year = $dates->year;
     }
 }

--- a/app/Components/Program/Program.latte
+++ b/app/Components/Program/Program.latte
@@ -1,3 +1,5 @@
+{varType App\Model\Entity\EventDates $dates}
+
 <section>
     <div class="wrapper">
         <div class="container text-center">

--- a/app/Components/Program/Program.latte
+++ b/app/Components/Program/Program.latte
@@ -1,4 +1,5 @@
 {varType App\Model\Entity\EventDates $dates}
+{varType App\Model\Entity\EventCounts $counts}
 
 <section>
     <div class="wrapper">

--- a/app/Components/Program/Program.latte
+++ b/app/Components/Program/Program.latte
@@ -1,6 +1,12 @@
 {varType App\Model\Entity\EventDates $dates}
 {varType App\Model\Entity\EventCounts $counts}
 
+{varType array $items}
+{varType array $timeRows}
+{varType array $rooms}
+{varType array $categories}
+{varType App\Model\TalkCategoryStyler $styler}
+
 <section>
     <div class="wrapper">
         <div class="container text-center">

--- a/app/Components/Schedule/Schedule.latte
+++ b/app/Components/Schedule/Schedule.latte
@@ -1,3 +1,5 @@
+{varType App\Model\Entity\EventDates $dates}
+
 <div class="schedule-container" id="schedule"
      data-features="{$features|json}"
      data-dates="{$dates|json}"

--- a/app/Components/Schedule/Schedule.latte
+++ b/app/Components/Schedule/Schedule.latte
@@ -1,4 +1,6 @@
 {varType App\Model\Entity\EventDates $dates}
+{varType App\Model\Entity\EventUrls $urls}
+{varType App\Model\Entity\EventFeatures $features}
 
 <div class="schedule-container" id="schedule"
      data-features="{$features|json}"

--- a/app/Components/SignupButtons/SignupButtons.latte
+++ b/app/Components/SignupButtons/SignupButtons.latte
@@ -1,3 +1,5 @@
+{varType App\Model\Entity\EventDates $dates}
+
 <div class="signup-buttons">
     <div class="signup-button visitor">
         <div class="item-icon">

--- a/app/Components/SignupButtons/SignupButtons.latte
+++ b/app/Components/SignupButtons/SignupButtons.latte
@@ -1,4 +1,5 @@
 {varType App\Model\Entity\EventDates $dates}
+{varType App\Model\Entity\EventFeatures $features}
 
 <div class="signup-buttons">
     <div class="signup-button visitor">

--- a/app/Components/SpeakerList/SpeakerListControl.php
+++ b/app/Components/SpeakerList/SpeakerListControl.php
@@ -40,7 +40,7 @@ class SpeakerListControl extends Control
 
         $this->template->setFile(__DIR__ . '/SpeakerList.latte');
         $this->template->talks = $talks;
-        $this->template->isProgram = $this->eventInfoProvider->getFeatures()['program'];
+        $this->template->isProgram = $this->eventInfoProvider->getFeatures()->program;
         $this->template->addFunction('gravatarize', $this->gravatarImageProvider->gravatarize(...));
         $this->template->render();
     }

--- a/app/Model/ArchiveManager.php
+++ b/app/Model/ArchiveManager.php
@@ -12,7 +12,7 @@ use Nette\Utils\JsonException;
 
 class ArchiveManager
 {
-    const IN_ARCHIVATION_COOKIE_KEY = '_in_archivation';
+    public const string IN_ARCHIVATION_COOKIE_KEY = '_in_archivation';
 
 
     /**
@@ -48,7 +48,7 @@ class ArchiveManager
         $currentYear = (new DateTime)->format('Y');
 
         try {
-            return (int)$this->config->get('dates.currentYear', $currentYear);
+            return (int)$this->config->get(EventInfoProvider::CURRENT_YEAR, $currentYear);
         } catch (JsonException) {
             return (int)$currentYear;
         }
@@ -61,7 +61,7 @@ class ArchiveManager
      */
     private function setCurrentYear($year): void
     {
-        $this->config->set('dates.currentYear', (int)$year);
+        $this->config->set(EventInfoProvider::CURRENT_YEAR, (int)$year);
     }
 
 

--- a/app/Model/Entity/DeprecatedArrayAccess.php
+++ b/app/Model/Entity/DeprecatedArrayAccess.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Model\Entity;
+
+use Nette\NotImplementedException;
+
+trait DeprecatedArrayAccess
+{
+    public function offsetExists(mixed $offset): bool
+    {
+        $fields = get_object_vars($this);
+        return array_key_exists($offset, $fields);
+    }
+
+    #[\Deprecated(message: "Array access is deprecated. Use property access instead.")]
+    public function offsetGet(mixed $offset): mixed
+    {
+        if (!$this->offsetExists($offset)) {
+            throw new \OutOfBoundsException("Offset '$offset' does not exist.");
+        }
+
+        return $this->{$offset};
+    }
+
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        throw new NotImplementedException();
+    }
+
+    public function offsetUnset(mixed $offset): void
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/app/Model/Entity/EventCounts.php
+++ b/app/Model/Entity/EventCounts.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Model\Entity;
+
+use ArrayAccess;
+
+readonly class EventCounts implements ArrayAccess
+{
+    use DeprecatedArrayAccess;
+
+    public function __construct(
+        public int $conferee,
+        public int $conferee_registered,
+        public int $conferee_left,
+        public int $talks,
+        public int $talks_limit,
+        public int $workshops,
+        public int $halls,
+        public int $warmupparty,
+        public int $afterparty,
+    ) {
+    }
+}

--- a/app/Model/Entity/EventDates.php
+++ b/app/Model/Entity/EventDates.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Model\Entity;
+
+use DateTimeInterface;
+
+readonly class EventDates implements \ArrayAccess, \JsonSerializable
+{
+    use DeprecatedArrayAccess;
+
+    public function __construct(
+        public int $year,
+        public DateTimeInterface $talks,
+        public DateTimeInterface $vote,
+        public DateTimeInterface $program,
+        public DateTimeInterface $event,
+        public DateTimeInterface $report,
+        public DateTimeInterface $scheduleBegin,
+        public DateTimeInterface $scheduleEnd,
+    ) {
+    }
+
+    public function jsonSerialize(): array
+    {
+        $data = get_object_vars($this);
+
+        $data = array_map(function ($value) {
+            if ($value instanceof DateTimeInterface) {
+                return $value->format(DateTimeInterface::ATOM);
+            }
+            return $value;
+        }, $data);
+
+        return $data;
+    }
+}

--- a/app/Model/Entity/EventFeatures.php
+++ b/app/Model/Entity/EventFeatures.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Model\Entity;
+
+use ArrayAccess;
+
+readonly class EventFeatures implements ArrayAccess
+{
+    use DeprecatedArrayAccess;
+
+    public function __construct(
+        public bool $conferee,
+        public bool $conferee_enabled,
+        public bool $talks,
+        public bool $talks_edit,
+        public string $talks_order,
+        public bool $vote,
+        public bool $show_vote,
+        public bool $program,
+        public bool $report,
+        public bool $talks_show,
+    ) {
+    }
+}

--- a/app/Model/Entity/EventUrls.php
+++ b/app/Model/Entity/EventUrls.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Model\Entity;
+
+use ArrayAccess;
+
+readonly class EventUrls implements ArrayAccess
+{
+    use DeprecatedArrayAccess;
+
+    public function __construct(
+        public string $facebook,
+        public string $twitter,
+        public string $youtube,
+        public string $instagram,
+        public string $way,
+        public string $ogImage,
+        public string $partnerProposal,
+    ) {
+    }
+}

--- a/app/Model/Entity/Org.php
+++ b/app/Model/Entity/Org.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Model\Entity;
+
+readonly class Org
+{
+    public function __construct(
+        public string $name,
+        public ?string $role,
+        public ?string $photo,
+        public ?string $phone,
+        public ?string $mail,
+        public ?string $homepage,
+        public ?string $facebook,
+        public ?string $twitter,
+    ) {
+    }
+
+    public static function from(array $array): self
+    {
+        return new self(
+            $array['name'],
+            $array['role'] ?? null,
+            $array['photo'] ?? null,
+            $array['phone'] ?? null,
+            $array['mail'] ?? null,
+            $array['homepage'] ?? null,
+            $array['facebook'] ?? null,
+            $array['twitter'] ?? null,
+        );
+    }
+}

--- a/app/Model/EventInfoProvider.php
+++ b/app/Model/EventInfoProvider.php
@@ -2,6 +2,8 @@
 
 namespace App\Model;
 
+use App\Model\Entity\EventDates;
+use DateTimeImmutable;
 use Nette\SmartObject;
 use Nette\Utils\ArrayHash;
 use Nette\Utils\DateTime;
@@ -50,19 +52,18 @@ class EventInfoProvider
     }
 
 
-    public function getDates(): ArrayHash
+    public function getDates(): EventDates
     {
-        return ArrayHash::from([
-            'year' => (int)$this->config->get(self::CURRENT_YEAR, (new DateTime())->format('Y')),
-
-            'talks' => DateTime::from($this->config->get(self::DATE_TALKS)),
-            'vote' => DateTime::from($this->config->get(self::DATE_VOTE)),
-            'program' => DateTime::from($this->config->get(self::DATE_PROGRAM)),
-            'event' => DateTime::from($this->config->get(self::DATE_EVENT)),
-            'report' => DateTime::from($this->config->get(self::DATE_REPORT)),
-            'scheduleBegin' => DateTime::from($this->config->get(self::SCHEDULE_VISUAL_DATE_BEGIN)),
-            'scheduleEnd' => DateTime::from($this->config->get(self::SCHEDULE_VISUAL_DATE_END)),
-        ]);
+        return new EventDates(
+            year: (int)$this->config->get(self::CURRENT_YEAR, new DateTimeImmutable()->format('Y')),
+            talks: new DateTimeImmutable($this->config->get(self::DATE_TALKS)),
+            vote: new DateTimeImmutable($this->config->get(self::DATE_VOTE)),
+            program: new DateTimeImmutable($this->config->get(self::DATE_PROGRAM)),
+            event: new DateTimeImmutable($this->config->get(self::DATE_EVENT)),
+            report: new DateTimeImmutable($this->config->get(self::DATE_REPORT)),
+            scheduleBegin: new DateTimeImmutable($this->config->get(self::SCHEDULE_VISUAL_DATE_BEGIN)),
+            scheduleEnd: new DateTimeImmutable($this->config->get(self::SCHEDULE_VISUAL_DATE_END)),
+        );
     }
 
 

--- a/app/Model/EventInfoProvider.php
+++ b/app/Model/EventInfoProvider.php
@@ -2,6 +2,7 @@
 
 namespace App\Model;
 
+use App\Model\Entity\EventCounts;
 use App\Model\Entity\EventDates;
 use App\Model\Entity\EventUrls;
 use DateTimeImmutable;
@@ -82,19 +83,19 @@ class EventInfoProvider
     }
 
 
-    public function getCounts(): ArrayHash
+    public function getCounts(): EventCounts
     {
-        return ArrayHash::from([
-            'conferee' => $this->config->get(self::COUNTS_CONFEREE),
-            'conferee_registered' => $this->getConfereeRegisteredCount(),
-            'conferee_left' => $this->getConfereeAvailableCount(),
-            'talks' => $this->config->get(self::COUNTS_TALKS),
-            'talks_limit' => $this->config->get(self::COUNTS_TALKS_LIMIT),
-            'workshops' => $this->config->get(self::COUNTS_WORKSHOPS),
-            'halls' => $this->config->get(self::COUNTS_HALLS),
-            'warmupparty' => $this->config->get(self::COUNTS_WARMUPPARTY),
-            'afterparty' => $this->config->get(self::COUNTS_AFTERPARTY),
-        ]);
+        return new EventCounts(
+           conferee: $this->config->get(self::COUNTS_CONFEREE),
+           conferee_registered: $this->getConfereeRegisteredCount(),
+           conferee_left: $this->getConfereeAvailableCount(),
+           talks: $this->config->get(self::COUNTS_TALKS),
+           talks_limit: $this->config->get(self::COUNTS_TALKS_LIMIT),
+           workshops: $this->config->get(self::COUNTS_WORKSHOPS),
+           halls: $this->config->get(self::COUNTS_HALLS),
+           warmupparty: $this->config->get(self::COUNTS_WARMUPPARTY),
+           afterparty: $this->config->get(self::COUNTS_AFTERPARTY),
+        );
     }
 
 

--- a/app/Model/EventInfoProvider.php
+++ b/app/Model/EventInfoProvider.php
@@ -3,6 +3,7 @@
 namespace App\Model;
 
 use App\Model\Entity\EventDates;
+use App\Model\Entity\EventUrls;
 use DateTimeImmutable;
 use Nette\SmartObject;
 use Nette\Utils\ArrayHash;
@@ -67,17 +68,17 @@ class EventInfoProvider
     }
 
 
-    public function getUrls(): ArrayHash
+    public function getUrls(): EventUrls
     {
-        return ArrayHash::from([
-            'facebook' => $this->config->get(self::URL_FACEBOOK),
-            'twitter' => $this->config->get(self::URL_TWITTER),
-            'youtube' => $this->config->get(self::URL_YOUTUBE),
-            'instagram' => $this->config->get(self::URL_INSTAGRAM),
-            'way' => $this->config->get(self::URL_WAY_TO_EVENT),
-            'ogImage' => $this->config->get(self::URL_OG_IMAGE),
-            'partnerProposal' => $this->config->get(self::URL_PARTNER_PROPOSAL),
-        ]);
+        return new EventUrls(
+            facebook: $this->config->get(self::URL_FACEBOOK),
+            twitter: $this->config->get(self::URL_TWITTER),
+            youtube: $this->config->get(self::URL_YOUTUBE),
+            instagram: $this->config->get(self::URL_INSTAGRAM),
+            way: $this->config->get(self::URL_WAY_TO_EVENT),
+            ogImage: $this->config->get(self::URL_OG_IMAGE),
+            partnerProposal: $this->config->get(self::URL_PARTNER_PROPOSAL),
+        );
     }
 
 

--- a/app/Model/EventInfoProvider.php
+++ b/app/Model/EventInfoProvider.php
@@ -4,11 +4,10 @@ namespace App\Model;
 
 use App\Model\Entity\EventCounts;
 use App\Model\Entity\EventDates;
+use App\Model\Entity\EventFeatures;
 use App\Model\Entity\EventUrls;
 use DateTimeImmutable;
 use Nette\SmartObject;
-use Nette\Utils\ArrayHash;
-use Nette\Utils\DateTime;
 
 class EventInfoProvider
 {
@@ -86,36 +85,38 @@ class EventInfoProvider
     public function getCounts(): EventCounts
     {
         return new EventCounts(
-           conferee: $this->config->get(self::COUNTS_CONFEREE),
-           conferee_registered: $this->getConfereeRegisteredCount(),
-           conferee_left: $this->getConfereeAvailableCount(),
-           talks: $this->config->get(self::COUNTS_TALKS),
-           talks_limit: $this->config->get(self::COUNTS_TALKS_LIMIT),
-           workshops: $this->config->get(self::COUNTS_WORKSHOPS),
-           halls: $this->config->get(self::COUNTS_HALLS),
-           warmupparty: $this->config->get(self::COUNTS_WARMUPPARTY),
-           afterparty: $this->config->get(self::COUNTS_AFTERPARTY),
+            conferee: $this->config->get(self::COUNTS_CONFEREE),
+            conferee_registered: $this->getConfereeRegisteredCount(),
+            conferee_left: $this->getConfereeAvailableCount(),
+            talks: $this->config->get(self::COUNTS_TALKS),
+            talks_limit: $this->config->get(self::COUNTS_TALKS_LIMIT),
+            workshops: $this->config->get(self::COUNTS_WORKSHOPS),
+            halls: $this->config->get(self::COUNTS_HALLS),
+            warmupparty: $this->config->get(self::COUNTS_WARMUPPARTY),
+            afterparty: $this->config->get(self::COUNTS_AFTERPARTY),
         );
     }
 
 
-    public function getFeatures(): ArrayHash
+    public function getFeatures(): EventFeatures
     {
-        $features = ArrayHash::from([
-            'conferee' => $this->isConfereeRegistrationAvailable(),
-            'conferee_enabled' => $this->config->get(self::FEATURE_CONFEREE),
-            'talks' => $this->config->get(self::FEATURE_TALK),
-            'talks_edit' => $this->config->get(self::FEATURE_TALK_EDIT),
-            'talks_order' => $this->config->get(self::FEATURE_TALK_ORDER),
-            'vote' => $this->config->get(self::FEATURE_VOTE),
-            'show_vote' => $this->config->get(self::FEATURE_SHOW_VOTE),
-            'program' => $this->config->get(self::FEATURE_PROGRAM),
-            'report' => $this->config->get(self::FEATURE_REPORT),
-        ]);
+        $talks = $this->config->get(self::FEATURE_TALK);
+        $vote = $this->config->get(self::FEATURE_VOTE);
+        $show_vote = $this->config->get(self::FEATURE_SHOW_VOTE);
+        $talks_show = $talks || $vote || $show_vote;
 
-        $features['talks_show'] = $features['talks'] || $features['vote'] || $features['show_vote'];
-
-        return $features;
+        return new EventFeatures(
+            conferee: $this->isConfereeRegistrationAvailable(),
+            conferee_enabled: $this->config->get(self::FEATURE_CONFEREE),
+            talks: $talks,
+            talks_edit: $this->config->get(self::FEATURE_TALK_EDIT),
+            talks_order: $this->config->get(self::FEATURE_TALK_ORDER),
+            vote: $vote,
+            show_vote: $show_vote,
+            program: $this->config->get(self::FEATURE_PROGRAM),
+            report: $this->config->get(self::FEATURE_REPORT),
+            talks_show: $talks_show,
+        );
     }
 
 

--- a/app/Model/EventInfoProvider.php
+++ b/app/Model/EventInfoProvider.php
@@ -13,37 +13,38 @@ class EventInfoProvider
 {
     use SmartObject;
 
-    public const CURRENT_YEAR = 'dates.currentYear';
+    public const string CURRENT_YEAR = 'dates.currentYear';
 
-    public const COUNTS_CONFEREE = 'counts.conferee';
-    public const COUNTS_TALKS = 'counts.talks';
-    public const COUNTS_TALKS_LIMIT = 'counts.talks.limit';
-    public const COUNTS_WORKSHOPS = 'counts.workshops';
-    public const COUNTS_HALLS = 'counts.halls';
-    public const COUNTS_WARMUPPARTY = 'counts.warmupparty';
-    public const COUNTS_AFTERPARTY = 'counts.afterparty';
-    public const DATE_TALKS = 'schedule.talks.date';
-    public const DATE_VOTE = 'schedule.vote.date';
-    public const DATE_EVENT = 'schedule.event.date';
-    public const DATE_PROGRAM = 'schedule.program.date';
-    public const DATE_REPORT = 'schedule.report.date';
-    public const FEATURE_CONFEREE = 'features.registerConferee.enabled';
-    public const FEATURE_TALK = 'features.registerTalk.enabled';
-    public const FEATURE_TALK_EDIT = 'features.editTalk.enabled';
-    public const FEATURE_TALK_ORDER = 'features.talk.order';
-    public const FEATURE_VOTE = 'features.voteTalk.enabled';
-    public const FEATURE_SHOW_VOTE = 'features.showVoteTalk.enabled';
-    public const FEATURE_PROGRAM = 'features.showProgram.enabled';
-    public const FEATURE_REPORT = 'features.showReport.enabled';
-    public const URL_FACEBOOK = 'url.social.facebook';
-    public const URL_TWITTER = 'url.social.twitter';
-    public const URL_YOUTUBE = 'url.social.youtube';
-    public const URL_INSTAGRAM = 'url.social.instagram';
-    public const URL_WAY_TO_EVENT = 'url.post.howToWay';
-    public const URL_OG_IMAGE = 'url.igImage';
-    public const URL_PARTNER_PROPOSAL = 'url.partnersProposal';
-    public const SCHEDULE_VISUAL_DATE_BEGIN = 'schedule.visualDate.begin';
-    public const SCHEDULE_VISUAL_DATE_END = 'schedule.visualDate.end';
+    public const string COUNTS_CONFEREE = 'counts.conferee';
+    public const string COUNTS_TALKS = 'counts.talks';
+    public const string COUNTS_TALKS_LIMIT = 'counts.talks.limit';
+    public const string COUNTS_WORKSHOPS = 'counts.workshops';
+    public const string COUNTS_HALLS = 'counts.halls';
+    public const string COUNTS_WARMUPPARTY = 'counts.warmupparty';
+    public const string COUNTS_AFTERPARTY = 'counts.afterparty';
+    public const string DATE_TALKS = 'schedule.talks.date';
+    public const string DATE_VOTE = 'schedule.vote.date';
+    public const string DATE_EVENT = 'schedule.event.date';
+    public const string DATE_PROGRAM = 'schedule.program.date';
+    public const string DATE_REPORT = 'schedule.report.date';
+    public const string FEATURE_CONFEREE = 'features.registerConferee.enabled';
+    public const string FEATURE_TALK = 'features.registerTalk.enabled';
+    public const string FEATURE_TALK_EDIT = 'features.editTalk.enabled';
+    public const string FEATURE_TALK_ORDER = 'features.talk.order';
+    public const string FEATURE_VOTE = 'features.voteTalk.enabled';
+    public const string FEATURE_SHOW_VOTE = 'features.showVoteTalk.enabled';
+    public const string FEATURE_PROGRAM = 'features.showProgram.enabled';
+    public const string FEATURE_REPORT = 'features.showReport.enabled';
+    public const string URL_FACEBOOK = 'url.social.facebook';
+    public const string URL_TWITTER = 'url.social.twitter';
+    public const string URL_YOUTUBE = 'url.social.youtube';
+    public const string URL_INSTAGRAM = 'url.social.instagram';
+    public const string URL_WAY_TO_EVENT = 'url.post.howToWay';
+    public const string URL_OG_IMAGE = 'url.igImage';
+    public const string URL_PARTNER_PROPOSAL = 'url.partnersProposal';
+    public const string SCHEDULE_VISUAL_DATE_BEGIN = 'schedule.visualDate.begin';
+    public const string SCHEDULE_VISUAL_DATE_END = 'schedule.visualDate.end';
+    public const string SCHEDULE_CURRENT_STEP = 'schedule.currentStep';
 
 
     public function __construct(

--- a/app/Model/OrgListModel.php
+++ b/app/Model/OrgListModel.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Model;
 
+use App\Model\Entity\Org;
 use Nette\Utils\ArrayHash;
 
 class OrgListModel
@@ -21,12 +22,15 @@ class OrgListModel
         return $this->configManager->get(self::LastUpdateUrlKeyConfigKey);
     }
 
+    /**
+     * @return iterable<Org>
+     */
     public function getOrgs(): iterable
     {
         $orgs = $this->configManager->get(self::ListConfigKey, []);
 
         foreach ($orgs as $org) {
-            yield ArrayHash::from($org);
+            yield Org::from($org);
         }
     }
 

--- a/app/Model/OrgListModel.php
+++ b/app/Model/OrgListModel.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace App\Model;
 
 use App\Model\Entity\Org;
-use Nette\Utils\ArrayHash;
 
 class OrgListModel
 {

--- a/app/Model/ScheduleManager.php
+++ b/app/Model/ScheduleManager.php
@@ -7,14 +7,14 @@ use Nette\Utils\DateTime;
 
 class ScheduleManager
 {
-    const NOFLAG = 0;
-    const REQUIRED = 1;
+    private const int NOFLAG = 0;
+    private const int REQUIRED = 1;
 
-    const IDX_KEY = 0;
-    const IDX_TYPE = 1;
-    const IDX_NAME = 2;
-    const IDX_FLAGS = 3;
-    const IDX_ENUM = 4;
+    private const int IDX_KEY = 0;
+    private const int IDX_TYPE = 1;
+    private const int IDX_NAME = 2;
+    private const int IDX_FLAGS = 3;
+    private const int IDX_ENUM = 4;
 
     private array $steps = [
         ['talks', 'Registrace přednášek'],
@@ -115,7 +115,7 @@ class ScheduleManager
      */
     public function setCurrentStep($value): void
     {
-        $this->configManager->set('schedule.currentStep', $value);
+        $this->configManager->set(Event::SCHEDULE_CURRENT_STEP, $value);
     }
 
 
@@ -218,7 +218,7 @@ class ScheduleManager
      */
     public function getCurrentStepKey()
     {
-        return $this->configManager->get('schedule.currentStep');
+        return $this->configManager->get(Event::SCHEDULE_CURRENT_STEP);
     }
 
 

--- a/app/Presenters/BasePresenter.php
+++ b/app/Presenters/BasePresenter.php
@@ -49,7 +49,7 @@ abstract class BasePresenter extends Nette\Application\UI\Presenter
         $dataLayer = new Nette\Utils\ArrayHash();
         if ($this->isArchivationProcess) {
             $dataLayer['isArchive'] = true;
-            $dataLayer['archiveYear'] = $dates['year'];
+            $dataLayer['archiveYear'] = $dates->year;
         }
 
         $this->template->wwwDir = $parameters['wwwDir'];
@@ -57,7 +57,7 @@ abstract class BasePresenter extends Nette\Application\UI\Presenter
         $this->template->dates = $dates;
         $this->template->features = $this->eventInfo->getFeatures();
         $this->template->socialUrls = $this->eventInfo->getUrls();
-        $this->template->year = $dates['year'];
+        $this->template->year = $dates->year;
 
         $this->template->dataLayer = $dataLayer;
 

--- a/app/Presenters/ConferencePresenter.php
+++ b/app/Presenters/ConferencePresenter.php
@@ -50,7 +50,7 @@ class ConferencePresenter extends BasePresenter
         );
         $categories = $this->talkManager->getCategories();
 
-        $sort = $this->eventInfoProvider->getFeatures()['talks_order'];
+        $sort = $this->eventInfoProvider->getFeatures()->talks_order;
         if ($sort === 'random') {
             $talks = $talks->fetchAll();
             shuffle($talks);
@@ -86,8 +86,8 @@ class ConferencePresenter extends BasePresenter
         }
 
         $this->template->votes = $votes;
-        $this->template->allowVote = $this->eventInfoProvider->getFeatures()['vote'];
-        $this->template->allowTalkEdit = $this->eventInfoProvider->getFeatures()['talks_edit'];
+        $this->template->allowVote = $this->eventInfoProvider->getFeatures()->vote;
+        $this->template->allowTalkEdit = $this->eventInfoProvider->getFeatures()->talks_edit;
         $this->template->selectedLimit = false;
 
         $talks_limit = $this->eventInfoProvider->getCounts()->talks_limit;
@@ -178,11 +178,11 @@ class ConferencePresenter extends BasePresenter
         $this->template->ogImageUrl = $extended['ogImageUrl'] ?? null;
 
         $features = $this->eventInfoProvider->getFeatures();
-        $this->template->allowVote = $features['vote'];
-        $this->template->showReport = $features['report'];
+        $this->template->allowVote = $features->vote;
+        $this->template->showReport = $features->report;
 
         $this->template->program = null;
-        if ($features['program'] && $talk->program->countStored()) {
+        if ($features->program && $talk->program->countStored()) {
             /** @var Program $program */
             $program = $talk->program->getIterator()->fetch();
 

--- a/app/Presenters/ConferencePresenter.php
+++ b/app/Presenters/ConferencePresenter.php
@@ -90,7 +90,7 @@ class ConferencePresenter extends BasePresenter
         $this->template->allowTalkEdit = $this->eventInfoProvider->getFeatures()['talks_edit'];
         $this->template->selectedLimit = false;
 
-        $talks_limit = $this->eventInfoProvider->getCounts()['talks_limit'];
+        $talks_limit = $this->eventInfoProvider->getCounts()->talks_limit;
 
         if ($sort === 'vote' && $talks_limit > 0) {
             $this->template->selectedLimit = $talks_limit;

--- a/app/Presenters/SignPresenter.php
+++ b/app/Presenters/SignPresenter.php
@@ -87,7 +87,7 @@ class SignPresenter extends BasePresenter
             $this->redirect('User:profil');
         }
 
-        if (!$this->eventInfoProvider->getFeatures()['conferee']) {
+        if (!$this->eventInfoProvider->getFeatures()->conferee) {
             $this->flashMessage('Registrace ještě nejsou otevřeny, omlouváme se');
             $this->redirect('Homepage:');
         }
@@ -96,7 +96,7 @@ class SignPresenter extends BasePresenter
 
     public function renderConferee(): void
     {
-        if (!$this->eventInfoProvider->getFeatures()['conferee']) {
+        if (!$this->eventInfoProvider->getFeatures()->conferee) {
             $this->flashMessage('Registrace ještě nejsou otevřeny, omlouváme se');
             $this->redirect('Homepage:');
         }
@@ -139,7 +139,7 @@ class SignPresenter extends BasePresenter
             $this->redirect('User:talk');
         }
 
-        if (!$this->eventInfoProvider->getFeatures()['talks']) {
+        if (!$this->eventInfoProvider->getFeatures()->talks) {
             $this->flashMessage('Vypisování přednášek není v tuto chvíli povoleno, omlouváme se');
             $this->redirect('Homepage:');
         }

--- a/app/Presenters/UserPresenter.php
+++ b/app/Presenters/UserPresenter.php
@@ -66,9 +66,9 @@ class UserPresenter extends BasePresenter
         $this->template->profileImage = $user->pictureUrl ?? $this->gravatar->getGravatarUrl($user->email);
 
         $features = $this->eventInfoProvider->getFeatures();
-        $this->template->allowRegisterConferee = $features['conferee'];
-        $this->template->allowRegisterTalk = $features['talks'];
-        $this->template->allowEditTalk = $features['talks_edit'];
+        $this->template->allowRegisterConferee = $features->conferee;
+        $this->template->allowRegisterTalk = $features->talks;
+        $this->template->allowEditTalk = $features->talks_edit;
     }
 
 
@@ -78,7 +78,7 @@ class UserPresenter extends BasePresenter
      */
     public function renderTalk(): void
     {
-        if (!$this->eventInfoProvider->getFeatures()['talks_edit']) {
+        if (!$this->eventInfoProvider->getFeatures()->talks_edit) {
             $this->flashMessage('Upravování přednášek není v tuto chvíli povoleno, omlouváme se');
             $this->redirect('profil');
         }

--- a/app/Presenters/templates/@layout.latte
+++ b/app/Presenters/templates/@layout.latte
@@ -2,6 +2,7 @@
 {varType array $flashes}
 
 {varType App\Model\Entity\EventUrls $socialUrls}
+{varType App\Model\Entity\EventFeatures $features}
 
 <!DOCTYPE html>
 <html lang="cs">

--- a/app/Presenters/templates/@layout.latte
+++ b/app/Presenters/templates/@layout.latte
@@ -1,7 +1,8 @@
-{**
- * @param string   $basePath web base path
- * @param array    $flashes  flash messages
- *}
+{varType string $basePath}
+{varType array $flashes}
+
+{varType App\Model\Entity\EventUrls $socialUrls}
+
 <!DOCTYPE html>
 <html lang="cs">
 <head>

--- a/app/Presenters/templates/@layout.latte
+++ b/app/Presenters/templates/@layout.latte
@@ -1,5 +1,7 @@
 {varType string $basePath}
 {varType array $flashes}
+{varType int $year}
+{varType bool $isArchivationProcess}
 
 {varType App\Model\Entity\EventUrls $socialUrls}
 {varType App\Model\Entity\EventFeatures $features}

--- a/app/Presenters/templates/Archived/list.latte
+++ b/app/Presenters/templates/Archived/list.latte
@@ -1,3 +1,6 @@
+{varType int $year}
+{varType array $archivedYears}
+
 {block title}Všechny ročníky{/block}
 {block content}
 <section>

--- a/app/Presenters/templates/Conference/talkDetail.latte
+++ b/app/Presenters/templates/Conference/talkDetail.latte
@@ -1,4 +1,12 @@
+{varType bool $allowVote}
+{varType bool $showReport}
+{varType ?string $ogImageUrl}
+{varType array $extended}
+
 {varType App\Model\Entity\EventFeatures $features}
+
+{varType App\Orm\Talk\Talk $talk}
+{varType App\Orm\Program\Program $program}
 
 {block title}Přednáška {$talk->title}{/block}
 {block ogImage}{ifset $ogImageUrl}{$ogImageUrl}{else}{gravatarize($talk->conferee->pictureUrl, $talk->conferee->email)}{/ifset}{/block}

--- a/app/Presenters/templates/Conference/talkDetail.latte
+++ b/app/Presenters/templates/Conference/talkDetail.latte
@@ -1,3 +1,5 @@
+{varType App\Model\Entity\EventFeatures $features}
+
 {block title}Přednáška {$talk->title}{/block}
 {block ogImage}{ifset $ogImageUrl}{$ogImageUrl}{else}{gravatarize($talk->conferee->pictureUrl, $talk->conferee->email)}{/ifset}{/block}
 {block content}

--- a/app/Presenters/templates/Conference/talkDetail.latte
+++ b/app/Presenters/templates/Conference/talkDetail.latte
@@ -6,7 +6,7 @@
 {varType App\Model\Entity\EventFeatures $features}
 
 {varType App\Orm\Talk\Talk $talk}
-{varType App\Orm\Program\Program $program}
+{varType ?array $program}
 
 {block title}Přednáška {$talk->title}{/block}
 {block ogImage}{ifset $ogImageUrl}{$ogImageUrl}{else}{gravatarize($talk->conferee->pictureUrl, $talk->conferee->email)}{/ifset}{/block}

--- a/app/Presenters/templates/Conference/talks.latte
+++ b/app/Presenters/templates/Conference/talks.latte
@@ -1,4 +1,5 @@
 {varType App\Model\Entity\EventDates $dates}
+{varType App\Model\Entity\EventFeatures $features}
 
 {block title}Přednášky{/block}
 {block content}

--- a/app/Presenters/templates/Conference/talks.latte
+++ b/app/Presenters/templates/Conference/talks.latte
@@ -1,3 +1,5 @@
+{varType App\Model\Entity\EventDates $dates}
+
 {block title}Přednášky{/block}
 {block content}
 

--- a/app/Presenters/templates/Conference/talks.latte
+++ b/app/Presenters/templates/Conference/talks.latte
@@ -1,3 +1,9 @@
+{varType array $talksInfo}
+{varType int $count}
+{varType array $votes}
+{varType bool $allowVote}
+{varType bool $selectedLimit}
+
 {varType App\Model\Entity\EventDates $dates}
 {varType App\Model\Entity\EventFeatures $features}
 

--- a/app/Presenters/templates/Conference/talks.latte
+++ b/app/Presenters/templates/Conference/talks.latte
@@ -2,7 +2,7 @@
 {varType int $count}
 {varType array $votes}
 {varType bool $allowVote}
-{varType bool $selectedLimit}
+{varType int|bool $selectedLimit}
 
 {varType App\Model\Entity\EventDates $dates}
 {varType App\Model\Entity\EventFeatures $features}

--- a/app/Presenters/templates/Homepage/contact.latte
+++ b/app/Presenters/templates/Homepage/contact.latte
@@ -1,3 +1,6 @@
+{varType int $year}
+{varType iterable $orgs}
+
 {block title}Kontakt{/block}
 {block content}
 <section>

--- a/app/Presenters/templates/Homepage/contact.latte
+++ b/app/Presenters/templates/Homepage/contact.latte
@@ -7,6 +7,7 @@
 
             <div class="organizers">
                 {foreach $orgs as $org}
+                    {varType \App\Model\Entity\Org $org}
                     <div class="organizer">
                         <h3><a n:tag-ifset="$org->homepage" href="{$org->homepage}" target="_blank" rel="noopener">{$org->name}</a></h3>
                         <a n:tag-ifset="$org->homepage" href="{$org->homepage}" target="_blank" rel="noopener"><img class="photo-pic" src="{ifset $org->photo}{if isAbsoluteUrl($org->photo)}{$org->photo}{else}{$basePath}/static/{$year}/img/contact/{$org->photo}{/if}{else}{$basePath}/static/{$year}/img/avatar.png{/ifset}" alt="{$org->name}" width="180" height="180"></a>

--- a/app/Presenters/templates/Homepage/default.latte
+++ b/app/Presenters/templates/Homepage/default.latte
@@ -1,10 +1,9 @@
 {varType string $wwwDir}
 {varType App\Model\Entity\EventDates $dates}
-{varType Nette\Utils\ArrayHash $features}
 {varType App\Model\Entity\EventUrls $socialUrls}
+{varType App\Model\Entity\EventCounts $counts}
+{varType Nette\Utils\ArrayHash $features}
 {varType int $year}
-
-{varType Nette\Utils\ArrayHash $counts}
 
 {block content}
 <div class="hero">

--- a/app/Presenters/templates/Homepage/default.latte
+++ b/app/Presenters/templates/Homepage/default.latte
@@ -1,7 +1,7 @@
 {varType string $wwwDir}
 {varType App\Model\Entity\EventDates $dates}
 {varType Nette\Utils\ArrayHash $features}
-{varType Nette\Utils\ArrayHash $socialUrls}
+{varType App\Model\Entity\EventUrls $socialUrls}
 {varType int $year}
 
 {varType Nette\Utils\ArrayHash $counts}

--- a/app/Presenters/templates/Homepage/default.latte
+++ b/app/Presenters/templates/Homepage/default.latte
@@ -1,5 +1,5 @@
 {varType string $wwwDir}
-{varType Nette\Utils\ArrayHash $dates}
+{varType App\Model\Entity\EventDates $dates}
 {varType Nette\Utils\ArrayHash $features}
 {varType Nette\Utils\ArrayHash $socialUrls}
 {varType int $year}

--- a/app/Presenters/templates/Homepage/default.latte
+++ b/app/Presenters/templates/Homepage/default.latte
@@ -2,7 +2,7 @@
 {varType App\Model\Entity\EventDates $dates}
 {varType App\Model\Entity\EventUrls $socialUrls}
 {varType App\Model\Entity\EventCounts $counts}
-{varType Nette\Utils\ArrayHash $features}
+{varType App\Model\Entity\EventFeatures $features}
 {varType int $year}
 
 {block content}

--- a/app/Presenters/templates/Homepage/default.latte
+++ b/app/Presenters/templates/Homepage/default.latte
@@ -1,9 +1,10 @@
-{varType string $wwwDir}
+{varType int $year}
+{varType bool $isArchivationProcess}
+
 {varType App\Model\Entity\EventDates $dates}
 {varType App\Model\Entity\EventUrls $socialUrls}
 {varType App\Model\Entity\EventCounts $counts}
 {varType App\Model\Entity\EventFeatures $features}
-{varType int $year}
 
 {block content}
 <div class="hero">

--- a/app/Presenters/templates/Homepage/history.latte
+++ b/app/Presenters/templates/Homepage/history.latte
@@ -1,3 +1,5 @@
+{varType App\Model\Entity\EventFeatures $features}
+
 {block title}O akci{/block}
 {block content}
 <section>

--- a/app/Presenters/templates/Homepage/history.latte
+++ b/app/Presenters/templates/Homepage/history.latte
@@ -1,3 +1,4 @@
+{varType int $year}
 {varType App\Model\Entity\EventFeatures $features}
 
 {block title}O akci{/block}

--- a/app/Presenters/templates/Homepage/partners.latte
+++ b/app/Presenters/templates/Homepage/partners.latte
@@ -1,3 +1,5 @@
+{varType App\Model\Entity\EventUrls $socialUrls}
+
 {block title}Partneři{/block}
 {block content}
 <section>
@@ -6,7 +8,7 @@
             <h1><span class="dot-end">Partneři</span></h1>
 
             <div class="text-center mt-xs">
-            <a href="{$socialUrls['partnerProposal']}" class="btn btn-brand btn-section mt-xs">Stáhnout informace o partnerství (PDF)</a>
+            <a href="{$socialUrls->partnerProposal}" class="btn btn-brand btn-section mt-xs">Stáhnout informace o partnerství (PDF)</a>
             </div>
 
             {control partners}

--- a/app/Presenters/templates/Homepage/partners.latte
+++ b/app/Presenters/templates/Homepage/partners.latte
@@ -1,3 +1,4 @@
+{varType bool $isArchivationProcess}
 {varType App\Model\Entity\EventUrls $socialUrls}
 
 {block title}Partneři{/block}

--- a/app/Presenters/templates/Sign/resetPasswordConfirm.latte
+++ b/app/Presenters/templates/Sign/resetPasswordConfirm.latte
@@ -1,3 +1,5 @@
+{varType string $username}
+
 {block title}Reset hesla{/block}
 {block content}
 

--- a/app/Presenters/templates/Sign/resetPasswordSent.latte
+++ b/app/Presenters/templates/Sign/resetPasswordSent.latte
@@ -1,3 +1,5 @@
+{varType ?string $mailUrl}
+
 {block title}Reset hesla{/block}
 {block content}
 

--- a/app/Presenters/templates/User/profil.latte
+++ b/app/Presenters/templates/User/profil.latte
@@ -1,3 +1,10 @@
+{varType ?App\Orm\Conferee\Conferee $conferee}
+{varType App\Orm\Talk\Talk[] $talks}
+{varType string $profileImage}
+{varType bool $allowRegisterConferee}
+{varType bool $allowRegisterTalk}
+{varType bool $allowEditTalk}
+
 {block title}Profil{/block}
 {block content}
 <section>
@@ -8,7 +15,7 @@
             <ul class="row people-list flexible mt-xs">
                 <li>
                     <div class="item">
-                        <div id="avatar" class="item-image" style="background-image: url('{gravatarize($user->identity->pictureUrl, $user->identity->email)}')"></div>
+                        <div id="avatar" class="item-image" style="background-image: url('{gravatarize($user->getIdentity()->pictureUrl, $user->getIdentity()->email)}')"></div>
                         <div class="item-content">
                           <div class="mb-sm">
                             <h2 class="item-title">Vstupenka</h2>
@@ -34,7 +41,7 @@
                             {/if}
                           </div>
 
-                            <h2 class="item-title">{$user->identity->name}</h2>
+                            <h2 class="item-title">{$user->getIdentity()->name}</h2>
                             <span n:if="$conferee" class="item-meta" title="{$conferee->bio|stripHtml}">{$conferee->bio|stripHtml|truncate:50|breakLines}</span>
                             <div class="item-text">
                                 {if $conferee}


### PR DESCRIPTION
Web má dynamicky definované stavy, které web provází harmonogramem fází přípravy na akci (fáze přihlašování, vypisování přednášek, hlasování, atd.) a z toho vyplývající zapínání konkrétních funkcí (formulář pro registraci přednášejících, tlačítko pro hlasování, ap.). To vše pochází z objektu `EventInfoProvider`, který aplikaci poskytuje jednotným způsobem informace o stavech a zapnutých funkcích a dále poskytuje také dynamické informace, jako je například počet přihlášených účastníků a nebo z toho vyplývající počet zbývajících vstupenek.

`EventInfoProvider` tyto informace poskytoval historicky jako asociativní pole, později jako objekt `ArrayHash` – v obou případech jde ale o dynamickou datovou strukturu.

Tento PR dynamickou strukturu mění na pevně typované objekty. Následně tyto typy definuje v Latte šablonách.

Nad rámec uvedeného je v rámci PR také otypováno jeden další objekt mimo `EventInfoProvider` (`Org`) a upraveny konstanty v `ScheduleManager`. Dále byly ve všech Latte šablonách frotntendu doplněny typy pro všechny proměnné, které jsou tam použity.

PR nemění funcionalitu. Protože původní volání bylo extrémně gumové a nedalo se staticky kompletně vystopovat, hrozí, že mohlo v kódu někde zůstat. Z  důvodu opatrnosti je tak u objektů ponechán `ArrayAccess`, který je označen `#[Deprecated]`, aby případné zavolání starého přístupu nerozbilo aplikaci, ale vygenerovalo záznam v logu.