### PR TITLE
sign: skip registration when already registered

### DIFF
--- a/app/Presenters/SignPresenter.php
+++ b/app/Presenters/SignPresenter.php
@@ -109,6 +109,10 @@ class SignPresenter extends BasePresenter
             $this->redirect('up');
         }
 
+        if($user->conferee) {
+            $this->redirect('User:profil');
+        }
+
         /** @var Form $form */
         $form = $this['confereeForm'];
         $form->setDefaults(


### PR DESCRIPTION
Oprava chyby – již přihlášený uživatel při vstupu na stránku `/registrace` vidí formulář, který ale při odeslání selže. 

Tento PR uživatele při vstupu na tuto stránku přesměruje na profil.