### PR TITLE
sign: closing registration with external registration (SimpleShop)

### DIFF
--- a/app/AdminModule/Presenters/DashboardPresenter.php
+++ b/app/AdminModule/Presenters/DashboardPresenter.php
@@ -72,7 +72,7 @@ class DashboardPresenter extends BasePresenter
         Event::URL_PARTNER_PROPOSAL => ['url', 'URL na Informace pro partnery (PDF)'],
         Event::URL_FORCE_EXTERNAL_REGISTRATION => [
             'url',
-            'Nahradit registrace vstupenkovým sytémem (URL)',
+            'Nahradit registrace vstupenkovým systémem (URL)',
             self::NOFLAG,
             'Vyplněním se uzavřou registrace a uživatel bude přesměrován na zadané URL. Po obnovení registrací URL vymažte.'
         ],

--- a/app/AdminModule/Presenters/DashboardPresenter.php
+++ b/app/AdminModule/Presenters/DashboardPresenter.php
@@ -70,6 +70,12 @@ class DashboardPresenter extends BasePresenter
         Event::URL_WAY_TO_EVENT => ['url', 'URL na článek Jak se k nám dostanete'],
         Event::URL_OG_IMAGE => ['url', 'URL na OG image', self::NOFLAG, 'Při nevyplnění se použije systémové logo'],
         Event::URL_PARTNER_PROPOSAL => ['url', 'URL na Informace pro partnery (PDF)'],
+        Event::URL_FORCE_EXTERNAL_REGISTRATION => [
+            'url',
+            'Nahradit registrace vstupenkovým sytémem (URL)',
+            self::NOFLAG,
+            'Vyplněním se uzavřou registrace a uživatel bude přesměrován na zadané URL. Po obnovení registrací URL vymažte.'
+        ],
     ];
 
     private array $featureConfigs = [

--- a/app/Model/Entity/EventUrls.php
+++ b/app/Model/Entity/EventUrls.php
@@ -18,6 +18,7 @@ readonly class EventUrls implements ArrayAccess
         public string $way,
         public string $ogImage,
         public string $partnerProposal,
+        public ?string $forceExternalRegistration = null,
     ) {
     }
 }

--- a/app/Model/EventInfoProvider.php
+++ b/app/Model/EventInfoProvider.php
@@ -42,6 +42,7 @@ class EventInfoProvider
     public const string URL_WAY_TO_EVENT = 'url.post.howToWay';
     public const string URL_OG_IMAGE = 'url.igImage';
     public const string URL_PARTNER_PROPOSAL = 'url.partnersProposal';
+    public const string URL_FORCE_EXTERNAL_REGISTRATION = 'url.forceExternalRegistration';
     public const string SCHEDULE_VISUAL_DATE_BEGIN = 'schedule.visualDate.begin';
     public const string SCHEDULE_VISUAL_DATE_END = 'schedule.visualDate.end';
     public const string SCHEDULE_CURRENT_STEP = 'schedule.currentStep';
@@ -79,6 +80,7 @@ class EventInfoProvider
             way: $this->config->get(self::URL_WAY_TO_EVENT),
             ogImage: $this->config->get(self::URL_OG_IMAGE),
             partnerProposal: $this->config->get(self::URL_PARTNER_PROPOSAL),
+            forceExternalRegistration: $this->config->get(self::URL_FORCE_EXTERNAL_REGISTRATION),
         );
     }
 

--- a/app/Presenters/SignPresenter.php
+++ b/app/Presenters/SignPresenter.php
@@ -87,6 +87,15 @@ class SignPresenter extends BasePresenter
             $this->redirect('User:profil');
         }
 
+        $forceExternalRegistrationUrl = $this->eventInfoProvider->getUrls()->forceExternalRegistration;
+        $this->template->forceExternalRegistrationUrl = $forceExternalRegistrationUrl;
+
+        // Registration is forced to an external system: show a redirect instead of
+        // the sign-up form, independently of the conferee feature flag.
+        if ($forceExternalRegistrationUrl) {
+            return;
+        }
+
         if (!$this->eventInfoProvider->getFeatures()->conferee) {
             $this->flashMessage('Registrace ještě nejsou otevřeny, omlouváme se');
             $this->redirect('Homepage:');

--- a/app/Presenters/SignPresenter.php
+++ b/app/Presenters/SignPresenter.php
@@ -87,6 +87,11 @@ class SignPresenter extends BasePresenter
             $this->redirect('User:profil');
         }
 
+        if (!$this->eventInfoProvider->getFeatures()->conferee) {
+            $this->flashMessage('Registrace ještě nejsou otevřeny, omlouváme se');
+            $this->redirect('Homepage:');
+        }
+
         $forceExternalRegistrationUrl = $this->eventInfoProvider->getUrls()->forceExternalRegistration;
         $this->template->forceExternalRegistrationUrl = $forceExternalRegistrationUrl;
 
@@ -94,11 +99,6 @@ class SignPresenter extends BasePresenter
         // the sign-up form, independently of the conferee feature flag.
         if ($forceExternalRegistrationUrl) {
             return;
-        }
-
-        if (!$this->eventInfoProvider->getFeatures()->conferee) {
-            $this->flashMessage('Registrace ještě nejsou otevřeny, omlouváme se');
-            $this->redirect('Homepage:');
         }
     }
 

--- a/app/Presenters/templates/Sign/up.latte
+++ b/app/Presenters/templates/Sign/up.latte
@@ -1,3 +1,5 @@
+{varType ?string $forceExternalRegistrationUrl}
+
 {block title}Registrace{/block}
 {block content}
 
@@ -5,41 +7,57 @@
     <div class="wrapper">
         <div class="container-wide">
             <div class="form-newsletter">
-                <div class="text-center">
-                    <span class="item-title">Registrace</span>
-                    <span class="text-md">Máte už účet? <a n:href="in">Přihlaste se</a></span>
-{*                    <div class="item-social mt-md mb-md">*}
-{*                        <a n:href="federatedLogin, 'platform'=>'facebook'" class="btn btn-section btn-lg btn-action">*}
-{*                            <span class="icon icon-facebook-1"><span class="path1"></span><span class="path2"></span></span> Facebook*}
-{*                        </a>*}
-{*                    </div>*}
-
-                </div>
-
-                <form n:name="signUpForm" class="mt-md">
-                    <ul class=error n:if="$form->ownErrors">
-                        <li n:foreach="$form->ownErrors as $error">{$error}</li>
-                    </ul>
-                    <div n:foreach="$form->controls as $name => $input"
-                            n:if="!$input->getOption(rendered) && $input->getOption(type) !== hidden"
-                            n:class="form-row, $input->getOption(itemClass), $input->required ? required, $input->error ? error">
-
-                        {label $input/}
-
-                        {if $input->getOption(type) in [text, select, textarea]}
-                            {input $input class => form-control}
-                        {elseif $input->getOption(type) === button}
-                            {input $input class => "btn btn-action btn-section text-upper"}
-                        {elseif $input->getOption(type) === checkbox}
-                        <div class="checkbox">{input $input:} {label $input:/}</div>
-                        {else}
-                            {input $input}
-                        {/if}
-                        <span class="error-text" n:ifcontent>{$input->error}</span>
-                        <span class="help-text" n:ifcontent>{$input->getOption(description)}</span>
+                {if $forceExternalRegistrationUrl}
+                    <div class="text-center">
+                        <span class="item-title">Registrace</span>
+                        <p class="text-md mt-md">
+                            Těsně před akcí už lze provést registraci jen v našem vstupenkovém systému.
+                        </p>
+                        <p class="text-md mt-md">
+                            Pokračujte na něj kliknutím na tlačítko níže.
+                        </p>
+                        <p class="mt-md">
+                            <a href="{$forceExternalRegistrationUrl}" class="btn btn-lg btn-brand btn-section text-bold">
+                                Pokračovat na registraci
+                            </a>
+                        </p>
                     </div>
-                </form>
+                {else}
+                    <div class="text-center">
+                        <span class="item-title">Registrace</span>
+                        <span class="text-md">Máte už účet? <a n:href="in">Přihlaste se</a></span>
+{*                        <div class="item-social mt-md mb-md">*}
+{*                            <a n:href="federatedLogin, 'platform'=>'facebook'" class="btn btn-section btn-lg btn-action">*}
+{*                                <span class="icon icon-facebook-1"><span class="path1"></span><span class="path2"></span></span> Facebook*}
+{*                            </a>*}
+{*                        </div>*}
 
+                    </div>
+
+                    <form n:name="signUpForm" class="mt-md">
+                        <ul class=error n:if="$form->ownErrors">
+                            <li n:foreach="$form->ownErrors as $error">{$error}</li>
+                        </ul>
+                        <div n:foreach="$form->controls as $name => $input"
+                                n:if="!$input->getOption(rendered) && $input->getOption(type) !== hidden"
+                                n:class="form-row, $input->getOption(itemClass), $input->required ? required, $input->error ? error">
+
+                            {label $input/}
+
+                            {if $input->getOption(type) in [text, select, textarea]}
+                                {input $input class => form-control}
+                            {elseif $input->getOption(type) === button}
+                                {input $input class => "btn btn-action btn-section text-upper"}
+                            {elseif $input->getOption(type) === checkbox}
+                            <div class="checkbox">{input $input:} {label $input:/}</div>
+                            {else}
+                                {input $input}
+                            {/if}
+                            <span class="error-text" n:ifcontent>{$input->error}</span>
+                            <span class="help-text" n:ifcontent>{$input->getOption(description)}</span>
+                        </div>
+                    </form>
+                {/if}
             </div>
         </div>
     </div>


### PR DESCRIPTION
PR přidává funkci, která umožňuje zavřít nové registrace a nasměrovat uživatele přímo na externí vstupenkový systém. Vhodné tam. kde se pro ověření vstupenek data ze systému vyexportují manuálně do externího systému a tím by se další registrace už nepřenesly. 

Je známé omezení, že pak tito uživatelé nubudou v naopak v tomto systému, ale to nevadí, protože účet učastníci na samotné akci nepotřebují (užitečný je jen pro vypsání přednáčky a hlasování o přednáškách, což se v průběhu samotné akce už nevyužije.

V nastavení přibylo nové pole, které vyžaduje URL. Při jeho vyplnění se místní registrace uzavře a uživatele vyzve k vyplnění dat přímo do nového systému.

<img width="507" height="371" alt="260522-h8tc4" src="https://github.com/user-attachments/assets/ac848aee-0dbf-43fa-aae5-1e84b4a8e029" />

<img width="506" height="494" alt="260522-nb2s6" src="https://github.com/user-attachments/assets/97ee909b-1784-48ec-bcdc-3bf96a23bee1" />
