### PR TITLE
docker: replace Mailcatcher with modern Maildev in devstack

### DIFF
--- a/app/config/config.neon
+++ b/app/config/config.neon
@@ -51,7 +51,7 @@ http:
 
 mail:
     smtp: true
-    host: mailcatcher
+    host: maildev
     port: 1025
 
 nextras.dbal:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,8 +24,9 @@ services:
         volumes:
             - "./.docker/mysql/data:/var/lib/mysql"
 
-    mailcatcher:
-        # https://github.com/sj26/mailcatcher
-        image: schickling/mailcatcher
+    maildev:
+        # https://maildev.github.io/maildev/
+        image: maildev/maildev
         ports:
             - "127.0.0.1:1080:1080"
+        restart: always


### PR DESCRIPTION
Mailcatcher je zastaralý, Maildev je moderní náhrada na stejném API.

Ovlivňuje pouze DEV verzi, nemá vliv na produkci.